### PR TITLE
Feat: 마이페이지 정보 조회 및 비밀번호 수정 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# Spring Boot secret 설정 파일 무시
+application-*.properties
+
 ### STS ###
 .apt_generated
 .classpath
@@ -17,21 +20,234 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
-### IntelliJ IDEA ###
-.idea
+# Created by https://www.toptal.com/developers/gitignore/api/java,intellij,macos,windows,netbeans,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij,macos,windows,netbeans,visualstudiocode
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
 *.iws
-*.iml
-*.ipr
+
+# IntelliJ
 out/
-!**/src/main/**/out/
-!**/src/test/**/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 ### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
 
-### VS Code ###
-.vscode/
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/basic,java,intellij,macos,windows,netbeans,visualstudiocode

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	implementation "com.querydsl:querydsl-core:5.1.0"
 	api "com.querydsl:querydsl-jpa:5.1.0:jakarta"
 	kapt "com.querydsl:querydsl-apt:5.1.0:jakarta"

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.pinkcat.quick_reserve_seller.auth.controller;
+
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.auth.service.AuthService;
+import com.pinkcat.quick_reserve_seller.common.security.principal.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto) {
+        return ResponseEntity.ok(authService.login(dto));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal UserPrincipal user) {
+        authService.logout(user.getUsername());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package com.pinkcat.quick_reserve_seller.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequestDto {
+  @NotBlank private String userId;
+  @NotBlank private String password;
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginResponseDto.java
@@ -1,0 +1,13 @@
+package com.pinkcat.quick_reserve_seller.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LoginResponseDto {
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.pinkcat.quick_reserve_seller.auth.service;
+
+
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+
+public interface AuthService {
+
+    LoginResponseDto login(LoginRequestDto dto);
+
+    void logout(String accessToken);
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
@@ -1,0 +1,53 @@
+package com.pinkcat.quick_reserve_seller.auth.service;
+
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.common.redis.RefreshTokenStore;
+import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtTokenProvider;
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final SellerRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
+    @Override
+    public LoginResponseDto login(LoginRequestDto dto) {
+        SellerEntity user =
+                userRepository
+                        .findById(dto.getUserId())
+                        .filter(SellerEntity::getActive)
+                        .filter(c -> passwordEncoder.matches(dto.getPassword(), c.getPassword()))
+                        .orElseThrow(
+                                () -> {
+                                    log.warn("[로그인 실패] ID/비밀번호 불일치 or 비활성화 계정: userId={}", dto.getUserId());
+                                    return new ResponseStatusException(
+                                            HttpStatus.UNAUTHORIZED, "사용자 ID 또는 비밀번호가 올바르지 않습니다.");
+                                });
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getPk());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getPk());
+
+        refreshTokenStore.save(user.getId(), refreshToken);
+        log.info("[로그인 성공] userId={}", user.getId());
+        return LoginResponseDto.builder().accessToken(accessToken).refreshToken(refreshToken).build();
+    }
+
+    @Override
+    public void logout(String userId) {
+        refreshTokenStore.delete(userId);
+        log.info("[로그아웃 성공] userId={}", userId);
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/exceptions/ErrorMessageCode.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/exceptions/ErrorMessageCode.java
@@ -15,6 +15,7 @@ public enum ErrorMessageCode {
 
     // Seller Exception - 80000
     SELLER_NOT_FOUND_EXCEPTION(80001, "seller_not_found_exception"),
+    SELLER_INACTIVE_EXCEPTION(80002, "seller inactive exception"),
 
     // Product Order Exception - 90000
     PRODUCT_ORDER_ITEM_NOT_FOUND_EXCEPTION(90001, "product_order_item_not_found_exception"),

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/exceptions/ErrorMessageCode.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/exceptions/ErrorMessageCode.java
@@ -16,11 +16,12 @@ public enum ErrorMessageCode {
     // Seller Exception - 80000
     SELLER_NOT_FOUND_EXCEPTION(80001, "seller_not_found_exception"),
     SELLER_INACTIVE_EXCEPTION(80002, "seller inactive exception"),
+    SELLER_INVALID_PASSWORD_EXCEPTION(80003, "seller invalid password"),
 
     // Product Order Exception - 90000
     PRODUCT_ORDER_ITEM_NOT_FOUND_EXCEPTION(90001, "product_order_item_not_found_exception"),
-    PRODUCT_ORDER_ITEM_STATUS_UPDATE_REQ_INVALID(90002, "product_order_item_status_update_req_invalid"),
-    ;
+    PRODUCT_ORDER_ITEM_STATUS_UPDATE_REQ_INVALID(90002, "product_order_item_status_update_req_invalid");
+
 
     private final int codeValue;
     private final String message;

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RedisConfig.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.pinkcat.quick_reserve_seller.common.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RefreshTokenStore.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RefreshTokenStore.java
@@ -1,0 +1,36 @@
+package com.pinkcat.quick_reserve_seller.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenStore {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "RT:ADMIN:";
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    public void save(String userId, String refreshToken) {
+        redisTemplate.opsForValue().set(PREFIX + userId, refreshToken, Duration.ofDays(refreshExpiration));
+    }
+
+    public String get(String userId) {
+        return redisTemplate.opsForValue().get(PREFIX + userId);
+    }
+
+    public void delete(String userId) {
+        redisTemplate.delete(PREFIX + userId);
+    }
+
+    public boolean isValid(String userId, String refreshToken) {
+        String stored = get(userId);
+        return refreshToken.equals(stored);
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/SecurityConfig.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/SecurityConfig.java
@@ -1,5 +1,9 @@
 package com.pinkcat.quick_reserve_seller.common.security;
 
+import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtAuthenticationFilter;
+import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtTokenProvider;
+import com.pinkcat.quick_reserve_seller.common.security.principal.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,26 +11,41 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(Customizer.withDefaults())
+        http.cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorize ->
-                        authorize
-                                .anyRequest()
-                                .permitAll()
-                );
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers("/api/auth/login", "/api/auth/signup")
+                                        .permitAll()
+                                        .anyRequest()
+                                        .authenticated())
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.pinkcat.quick_reserve_seller.common.security.jwt;
+
+import com.pinkcat.quick_reserve_seller.common.security.principal.UserDetailsServiceImpl;
+import com.pinkcat.quick_reserve_seller.common.security.principal.UserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Long userPk = jwtTokenProvider.getUserPk(token);
+
+            UserPrincipal userDetails = userDetailsService.loadUserByPk(userPk);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7); // "Bearer " 이후
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,90 @@
+package com.pinkcat.quick_reserve_seller.common.security.jwt;
+
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+    private final SellerRepository userRepository;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-expiration}")
+    private long accessExpiration;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    private Key key;
+
+    public JwtTokenProvider(SellerRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String createAccessToken(Long userPk) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessExpiration);
+
+        log.debug("AccessToken 생성 완료: userPk={}, expiresAt={}", userPk, expiry);
+
+        return Jwts.builder()
+                .setSubject(userPk.toString())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userPk) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshExpiration);
+
+        log.debug("RefreshToken 생성 완료: userPk={}, expiresAt={}", userPk, expiry);
+
+        return Jwts.builder()
+                .setSubject(userPk.toString())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getUserPk(String token) {
+        try {
+            Claims claims =
+                    Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("토큰 파싱 실패: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("토큰 검증 실패: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/principal/UserDetailsServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/principal/UserDetailsServiceImpl.java
@@ -1,0 +1,40 @@
+package com.pinkcat.quick_reserve_seller.common.security.principal;
+
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final SellerRepository userRepository;
+
+    @Override
+    public UserPrincipal loadUserByUsername(String username) throws UsernameNotFoundException {
+        SellerEntity user =
+                userRepository
+                        .findById(username)
+                        .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다: " + username));
+        return new UserPrincipal(user);
+    }
+
+    public UserPrincipal loadUserByPk(Long userPk) {
+        SellerEntity user =
+                userRepository
+                        .findById(userPk)
+                        .orElseThrow(
+                                () -> {
+                                    log.warn("토큰 내 사용자 조회 실패: userPk={}", userPk);
+                                    return new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+                                });
+        return new UserPrincipal(user);
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/principal/UserPrincipal.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/principal/UserPrincipal.java
@@ -1,0 +1,58 @@
+package com.pinkcat.quick_reserve_seller.common.security.principal;
+
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final SellerEntity user;
+
+    public UserPrincipal(SellerEntity user) {
+        this.user = user;
+    }
+
+    public Long getUserPk() {
+        return user.getPk();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList(); // Role 없는 구조
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getId(); // 로그인 ID
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/controller/SellerController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/controller/SellerController.java
@@ -1,0 +1,24 @@
+package com.pinkcat.quick_reserve_seller.seller.controller;
+
+import com.pinkcat.quick_reserve_seller.common.security.principal.UserPrincipal;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+import com.pinkcat.quick_reserve_seller.seller.service.SellerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mypage/me")
+@RequiredArgsConstructor
+public class SellerController {
+    private final SellerService sellerService;
+
+    @GetMapping
+    public ResponseEntity<SellerGetResponseDto> getMyInfo(
+            @AuthenticationPrincipal UserPrincipal user) {
+        return ResponseEntity.ok(sellerService.getMyInfo(user.getUserPk()));
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/controller/SellerController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/controller/SellerController.java
@@ -2,13 +2,13 @@ package com.pinkcat.quick_reserve_seller.seller.controller;
 
 import com.pinkcat.quick_reserve_seller.common.security.principal.UserPrincipal;
 import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerUpdatePasswordRequestDto;
 import com.pinkcat.quick_reserve_seller.seller.service.SellerService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/mypage/me")
@@ -20,5 +20,13 @@ public class SellerController {
     public ResponseEntity<SellerGetResponseDto> getMyInfo(
             @AuthenticationPrincipal UserPrincipal user) {
         return ResponseEntity.ok(sellerService.getMyInfo(user.getUserPk()));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updateMyPassword(
+            @AuthenticationPrincipal UserPrincipal user,
+            @RequestBody @Valid SellerUpdatePasswordRequestDto dto) {
+        sellerService.updatePassword(user.getUserPk(), dto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/dto/SellerGetResponseDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/dto/SellerGetResponseDto.java
@@ -1,0 +1,36 @@
+package com.pinkcat.quick_reserve_seller.seller.dto;
+
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.store.entity.StoreEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SellerGetResponseDto {
+  private Long sellerPk;
+  private String sellerId;
+  private String sellerName;
+  private String sellerPhoneNumber;
+  private String sellerEmail;
+
+  private String storeName;
+  private String storeAddress;
+  private String storeContactNumber;
+
+  public static SellerGetResponseDto fromEntity(SellerEntity seller) {
+    StoreEntity store = seller.getStore();
+    return SellerGetResponseDto.builder()
+            .sellerPk(seller.getPk())
+            .sellerId(seller.getId())
+            .sellerName(seller.getName())
+            .sellerPhoneNumber(seller.getPhoneNumber())
+            .sellerEmail(seller.getEmail())
+            .storeName(store.getName())
+            .storeAddress(store.getAddress())
+            .storeContactNumber(store.getContactNumber())
+            .build();
+  }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/dto/SellerUpdatePasswordRequestDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/dto/SellerUpdatePasswordRequestDto.java
@@ -1,0 +1,18 @@
+package com.pinkcat.quick_reserve_seller.seller.dto;
+
+import com.pinkcat.quick_reserve_seller.seller.validation.PasswordValid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SellerUpdatePasswordRequestDto {
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    @PasswordValid
+    private String newPassword;
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerService.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerService.java
@@ -1,7 +1,10 @@
 package com.pinkcat.quick_reserve_seller.seller.service;
 
 import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerUpdatePasswordRequestDto;
 
 public interface SellerService {
   SellerGetResponseDto getMyInfo(Long userPk);
+
+  void updatePassword(Long userPk, SellerUpdatePasswordRequestDto dto);
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerService.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerService.java
@@ -1,0 +1,7 @@
+package com.pinkcat.quick_reserve_seller.seller.service;
+
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+
+public interface SellerService {
+  SellerGetResponseDto getMyInfo(Long userPk);
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImpl.java
@@ -1,0 +1,32 @@
+package com.pinkcat.quick_reserve_seller.seller.service;
+
+import com.pinkcat.quick_reserve_seller.common.exceptions.ErrorMessageCode;
+import com.pinkcat.quick_reserve_seller.common.exceptions.PinkCatException;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SellerServiceImpl implements SellerService {
+    private final SellerRepository sellerRepository;
+
+    @Override
+    public SellerGetResponseDto getMyInfo(Long userPk) {
+        SellerEntity seller =
+                sellerRepository
+                        .findByPkAndActiveTrue(userPk)
+                        .orElseThrow(
+                                () -> {
+                                    log.warn("[내 정보 조회 실패] 비활성화 계정/계정 없음: userPk={}", userPk);
+                                    throw new PinkCatException(
+                                            "비활성화된 계정입니다. 관리자에게 문의해주세요.", ErrorMessageCode.SELLER_INACTIVE_EXCEPTION);
+                                });
+
+        return SellerGetResponseDto.fromEntity(seller);
+    }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImpl.java
@@ -3,17 +3,21 @@ package com.pinkcat.quick_reserve_seller.seller.service;
 import com.pinkcat.quick_reserve_seller.common.exceptions.ErrorMessageCode;
 import com.pinkcat.quick_reserve_seller.common.exceptions.PinkCatException;
 import com.pinkcat.quick_reserve_seller.seller.dto.SellerGetResponseDto;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerUpdatePasswordRequestDto;
 import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
 import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SellerServiceImpl implements SellerService {
     private final SellerRepository sellerRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public SellerGetResponseDto getMyInfo(Long userPk) {
@@ -28,5 +32,39 @@ public class SellerServiceImpl implements SellerService {
                                 });
 
         return SellerGetResponseDto.fromEntity(seller);
+    }
+
+    @Transactional
+    public void updatePassword(Long sellerPk, SellerUpdatePasswordRequestDto dto) {
+        SellerEntity seller =
+                sellerRepository
+                        .findByPkAndActiveTrue(sellerPk)
+                        .orElseThrow(
+                                () -> {
+                                    log.warn("[비밀번호 변경 실패] 비활성화 계정/계정 없음: sellerPk={}", sellerPk);
+                                    return new PinkCatException(
+                                            "비활성화된 계정입니다. 관리자에게 문의해주세요.", ErrorMessageCode.SELLER_INACTIVE_EXCEPTION);
+                                });
+
+        if (dto.getNewPassword() == null || dto.getNewPassword().isBlank()) {
+            log.warn("[비밀번호 변경 실패] 새 비밀번호 값 누락: sellerPk={}", sellerPk);
+            throw new PinkCatException("비밀번호는 필수 값입니다.", ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION);
+        }
+
+        if (passwordEncoder.matches(dto.getNewPassword(), seller.getPassword())) {
+            log.warn("[비밀번호 변경 실패] 새 비밀번호 기존과 동일: sellerPk={}", sellerPk);
+            throw new PinkCatException("새 비밀번호가 기존과 같습니다.", ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION);
+        }
+
+        if (!passwordEncoder.matches(dto.getPassword(), seller.getPassword())) {
+            log.warn("[비밀번호 변경 실패] 기존 비밀번호 불일치: sellerPk={}", sellerPk);
+            throw new PinkCatException("현재 비밀번호가 일치하지 않습니다.", ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION);
+        }
+
+        seller.updateEncodedPassword(passwordEncoder.encode(dto.getNewPassword()));
+
+        log.info("[비밀번호 변경 성공] sellerPk={}", sellerPk);
+
+        sellerRepository.save(seller);
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/PasswordValid.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/PasswordValid.java
@@ -1,0 +1,18 @@
+package com.pinkcat.quick_reserve_seller.seller.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PasswordValid {
+  String message() default "{user.password.invalid}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/PasswordValidator.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/PasswordValidator.java
@@ -1,0 +1,16 @@
+package com.pinkcat.quick_reserve_seller.seller.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class PasswordValidator implements ConstraintValidator<PasswordValid, String> {
+  private static final Pattern PATTERN = Pattern.compile(SellerValidationPatterns.PASSWORD);
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null || value.isBlank()) return true;
+    return PATTERN.matcher(value).matches();
+  }
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/SellerValidationPatterns.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/seller/validation/SellerValidationPatterns.java
@@ -1,0 +1,65 @@
+package com.pinkcat.quick_reserve_seller.seller.validation;
+
+public class SellerValidationPatterns {
+  private SellerValidationPatterns() {}
+
+  /**
+   * ID
+   *
+   * <ul>
+   *   <li>영문 소문자, 숫자, 밑줄(_)만 허용
+   *   <li>4~20자
+   *   <li>공백/대문자/특수문자 불가
+   *   <li>예: user_123
+   * </ul>
+   */
+  public static final String ID = "^[a-z0-9_]{4,20}$";
+
+  /**
+   * 이름
+   *
+   * <ul>
+   *   <li>한글 또는 영문만 허용
+   *   <li>2~20자
+   *   <li>숫자/특수문자/공백 불가
+   *   <li>예: 홍길동, John
+   * </ul>
+   */
+  public static final String NAME = "^[a-zA-Z가-힣]{2,20}$";
+
+  /**
+   * 비밀번호
+   *
+   * <ul>
+   *   <li>영문 + 숫자 필수 포함
+   *   <li>특수문자 허용
+   *   <li>8~20자
+   *   <li>공백 불가
+   *   <li>권장: 영문+숫자+특수문자 조합
+   *   <li>예: abc12345, abc123!@
+   * </ul>
+   */
+  public static final String PASSWORD = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+=-]{8,20}$";
+
+  /**
+   * 휴대폰 번호 (하이픈 포함)
+   *
+   * <ul>
+   *   <li>010-1234-5678 형식
+   *   <li>02-123-4567 등 지역번호 지원
+   * </ul>
+   */
+  public static final String PHONE_NUMBER = "^\\d{2,3}-\\d{3,4}-\\d{4}$";
+
+  /**
+   * 이메일
+   *
+   * <ul>
+   *   <li>영문/숫자/._+- 허용 (로컬 파트)
+   *   <li>@ 포함
+   *   <li>도메인에 . 포함
+   *   <li>예: user.name+tag@example.com
+   * </ul>
+   */
+  public static final String EMAIL = "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$";
+}

--- a/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/entity/SellerEntity.kt
+++ b/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/entity/SellerEntity.kt
@@ -14,9 +14,13 @@ import lombok.Data
 class SellerEntity(
         val id: String,
         val name: String,
-        val password: String,
+        var password: String,
         val phoneNumber: String,
         val email: String,
         @ManyToOne(fetch = FetchType.LAZY)
         val store: StoreEntity? = null
-) : BaseEntity()
+) : BaseEntity() {
+    fun updateEncodedPassword(newEncodedPassword: String) {
+        this.password = newEncodedPassword
+    }
+}

--- a/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/entity/SellerEntity.kt
+++ b/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/entity/SellerEntity.kt
@@ -1,7 +1,10 @@
 package com.pinkcat.quick_reserve_seller.seller.entity
 
 import com.pinkcat.quick_reserve_seller.common.model.BaseEntity
+import com.pinkcat.quick_reserve_seller.store.entity.StoreEntity
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import lombok.Data
 
@@ -9,8 +12,11 @@ import lombok.Data
 @Data
 @Table(name = "seller")
 class SellerEntity(
-    val name: String,
-    val password: String,
-    val phoneNumber: String,
-    val email: String
+        val id: String,
+        val name: String,
+        val password: String,
+        val phoneNumber: String,
+        val email: String,
+        @ManyToOne(fetch = FetchType.LAZY)
+        val store: StoreEntity? = null
 ) : BaseEntity()

--- a/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/repository/SellerRepository.kt
+++ b/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/repository/SellerRepository.kt
@@ -6,4 +6,6 @@ import java.util.*
 
 interface SellerRepository : ActiveRepository<SellerEntity, Long> {
     fun findById(userId: String): Optional<SellerEntity>
+    fun findByPkAndActiveTrue(customerPk: Long): Optional<SellerEntity>
+
 }

--- a/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/repository/SellerRepository.kt
+++ b/src/main/kotlin/com/pinkcat/quick_reserve_seller/seller/repository/SellerRepository.kt
@@ -2,6 +2,8 @@ package com.pinkcat.quick_reserve_seller.seller.repository
 
 import com.pinkcat.quick_reserve_seller.common.repository.ActiveRepository
 import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity
+import java.util.*
 
 interface SellerRepository : ActiveRepository<SellerEntity, Long> {
+    fun findById(userId: String): Optional<SellerEntity>
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=quick-reserve-seller
+spring.profiles.active=secret
 # ===============================
 # = Error
 # ===============================
@@ -10,10 +11,6 @@ server.error.include-exception=true
 # ===============================
 # = Data Source
 # ===============================
-spring.datasource.url=jdbc:mysql://localhost:3306/pink_cat
-spring.datasource.username=root
-spring.datasource.password=123456
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.properties.hibernate.hbm2ddl.auto=update
 spring.jpa.properties.hibernate.id.new_generator_mappings=IDENTITY
@@ -25,5 +22,3 @@ spring.jpa.properties.hibernate.physical_naming_strategy=org.hibernate.boot.mode
 # ===============================
 aws.region=ap-northeast-2
 aws.s3.bucket.product.image=pinkcat/product/image
-aws.access-key=
-aws.secret-key=

--- a/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,139 @@
+package com.pinkcat.quick_reserve_seller.auth.service;
+
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.common.redis.RefreshTokenStore;
+import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtTokenProvider;
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import com.pinkcat.quick_reserve_seller.store.entity.StoreEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthServiceImplTest {
+
+    @Mock
+    private SellerRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    private SellerEntity userEntity;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        userEntity =
+                new SellerEntity("testuser",
+                        "테스트유저",
+                        "encoded_pass",
+                        "01012341234",
+                        "testuser@test.com",
+                        new StoreEntity());
+        userEntity.setPk(1L);
+    }
+
+    @Nested
+    class LoginTest {
+
+        @Test
+        void 성공() {
+            // given
+            LoginRequestDto loginDto = new LoginRequestDto("testuser", "rawpass");
+            when(userRepository.findById("testuser")).thenReturn(Optional.of(userEntity));
+            when(passwordEncoder.matches("rawpass", "encoded_pass")).thenReturn(true);
+            when(jwtTokenProvider.createAccessToken(1L)).thenReturn("access-token");
+            when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
+
+            // when
+            LoginResponseDto result = authService.login(loginDto);
+
+            // then
+            assertEquals("access-token", result.getAccessToken());
+            assertEquals("refresh-token", result.getRefreshToken());
+            verify(refreshTokenStore).save("testuser", "refresh-token");
+        }
+
+        @Test
+        void 실패_존재하지않는ID() {
+            // given
+            LoginRequestDto loginDto = new LoginRequestDto("wronguser", "rawpass");
+            when(userRepository.findById("wronguser")).thenReturn(Optional.empty());
+
+            // when
+            ResponseStatusException ex =
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+
+            // then
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        }
+
+        @Test
+        void 실패_비밀번호불일치() {
+            // given
+            LoginRequestDto loginDto = new LoginRequestDto("testuser", "wrongpass");
+            when(userRepository.findById("testuser")).thenReturn(Optional.of(userEntity));
+            when(passwordEncoder.matches("wrongpass", "encoded_pass")).thenReturn(false);
+
+            // when
+            ResponseStatusException ex =
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+
+            // then
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        }
+
+        @Test
+        void 실패_비활성화된계정() {
+            // given
+            LoginRequestDto loginDto = new LoginRequestDto("testuser", "rawpass");
+
+            userEntity.setActive(false);
+            when(userRepository.findById("testuser")).thenReturn(Optional.of(userEntity));
+
+            // when
+            ResponseStatusException ex =
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+
+            // then
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        }
+
+    }
+
+    @Nested
+    class LogoutTest {
+
+        @Test
+        void 성공() {
+            // given
+            String userId = "testuser";
+
+            // when
+            assertDoesNotThrow(() -> authService.logout(userId));
+
+            // then
+            verify(refreshTokenStore).delete(userId);
+        }
+    }
+}

--- a/src/test/java/com/pinkcat/quick_reserve_seller/product/service/ProductServiceImplTest.kt
+++ b/src/test/java/com/pinkcat/quick_reserve_seller/product/service/ProductServiceImplTest.kt
@@ -70,6 +70,7 @@ class ProductServiceImplTest {
         )
 
         private fun getSeller(pk: Long = 1): SellerEntity = SellerEntity(
+            id = "seller",
             name = "seller",
             password = "password",
             phoneNumber = "01000000001",
@@ -208,6 +209,7 @@ class ProductServiceImplTest {
 
         fun makeProduct(productPk: Long = 1L, categoryPks: List<Long>): ProductEntity {
             val seller = SellerEntity(
+                id = "seller",
                 name = "seller",
                 password = "password",
                 phoneNumber = "01000000001",
@@ -258,6 +260,7 @@ class ProductServiceImplTest {
 
         fun makeProduct(productPk: Long = 1L, categoryPks: List<Long>): ProductEntity {
             val seller = SellerEntity(
+                id = "seller",
                 name = "seller",
                 password = "password",
                 phoneNumber = "01000000001",
@@ -488,6 +491,7 @@ class ProductServiceImplTest {
     )
 
     private fun getSeller(pk: Long = 1): SellerEntity = SellerEntity(
+        id = "seller",
         name = "seller",
         password = "password",
         phoneNumber = "01000000001",

--- a/src/test/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImplTest.java
+++ b/src/test/java/com/pinkcat/quick_reserve_seller/seller/service/SellerServiceImplTest.java
@@ -1,0 +1,183 @@
+package com.pinkcat.quick_reserve_seller.seller.service;
+
+import com.pinkcat.quick_reserve_seller.common.exceptions.ErrorMessageCode;
+import com.pinkcat.quick_reserve_seller.common.exceptions.PinkCatException;
+import com.pinkcat.quick_reserve_seller.seller.dto.SellerUpdatePasswordRequestDto;
+import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
+import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import com.pinkcat.quick_reserve_seller.store.entity.StoreEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SellerServiceImplTest {
+    @Mock
+    private SellerRepository sellerRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private SellerServiceImpl sellerService;
+
+    private SellerEntity activeSeller;
+    private SellerEntity inactiveSeller;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        activeSeller = new SellerEntity("activetestuser",
+                "활성화테스트유저",
+                "encoded_pass",
+                "01012341234",
+                "activetest@example.com",
+                new StoreEntity());
+        activeSeller.setPk(1L);
+
+        inactiveSeller = new SellerEntity("inactivetestuser",
+                "비활성화테스트유저",
+                "encoded_pass",
+                "01012341234",
+                "inactivetest@example.com",
+                new StoreEntity());
+        inactiveSeller.setActive(false);
+        inactiveSeller.setPk(2L);
+
+    }
+
+    @Nested
+    class UpdatePasswordTest {
+
+        @Test
+        void 성공() {
+            // given
+            Long sellerPk = activeSeller.getPk();
+            String currentRaw = "oldPassword";
+            String newRaw = "newPassword";
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk))
+                    .thenReturn(Optional.of(activeSeller));
+            when(passwordEncoder.matches(currentRaw, activeSeller.getPassword())).thenReturn(true);
+            when(passwordEncoder.matches(newRaw, activeSeller.getPassword())).thenReturn(false);
+            when(passwordEncoder.encode(newRaw)).thenReturn("encodedNewPassword");
+
+            // when
+            sellerService.updatePassword(
+                    sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw));
+
+            // then
+            verify(sellerRepository).save(activeSeller);
+            assertEquals("encodedNewPassword", activeSeller.getPassword());
+        }
+
+        @Test
+        void 실패_새비밀번호누락_null() {
+            // given
+            Long sellerPk = activeSeller.getPk();
+            String currentRaw = "oldPassword";
+            String newRaw = null;
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk))
+                    .thenReturn(Optional.of(activeSeller));
+            when(passwordEncoder.matches(currentRaw, activeSeller.getPassword())).thenReturn(true);
+
+            // when
+            PinkCatException ex = assertThrows(
+                    PinkCatException.class, () ->
+                            sellerService.updatePassword(
+                                    sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw)));
+
+            // then
+            assertEquals(ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION, ex.getPinkCatErrorMessageCode());
+        }
+
+        @Test
+        void 실패_새비밀번호누락_blank() {
+            // given
+            Long sellerPk = activeSeller.getPk();
+            String currentRaw = "oldPassword";
+            String newRaw = " ";
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk))
+                    .thenReturn(Optional.of(activeSeller));
+            when(passwordEncoder.matches(currentRaw, activeSeller.getPassword())).thenReturn(true);
+
+            // when
+            PinkCatException ex = assertThrows(PinkCatException.class, () ->
+                    sellerService.updatePassword(
+                            sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw)));
+
+            // then
+            assertEquals(ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION, ex.getPinkCatErrorMessageCode());
+        }
+
+        @Test
+        void 실패_새비밀번호가기존과동일() {
+            // given
+            Long sellerPk = activeSeller.getPk();
+            String currentRaw = "samePassword";
+            String newRaw = "samePassword";
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk))
+                    .thenReturn(Optional.of(activeSeller));
+            when(passwordEncoder.matches(currentRaw, activeSeller.getPassword())).thenReturn(true);
+            when(passwordEncoder.matches(newRaw, activeSeller.getPassword())).thenReturn(true);
+
+            // when
+            PinkCatException ex = assertThrows(PinkCatException.class, () ->
+                    sellerService.updatePassword(
+                            sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw)));
+
+            // then
+            assertEquals(ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION, ex.getPinkCatErrorMessageCode());
+        }
+
+        @Test
+        void 실패_현재비밀번호불일치() {
+            // given
+            Long sellerPk = activeSeller.getPk();
+            String currentRaw = "wrongPassword";
+            String newRaw = "newPassword";
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk))
+                    .thenReturn(Optional.of(activeSeller));
+            when(passwordEncoder.matches(currentRaw, activeSeller.getPassword())).thenReturn(false);
+
+            // when
+            PinkCatException ex = assertThrows(PinkCatException.class, () ->
+                    sellerService.updatePassword(
+                            sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw)));
+
+            // then
+            assertEquals(ErrorMessageCode.SELLER_INVALID_PASSWORD_EXCEPTION, ex.getPinkCatErrorMessageCode());
+        }
+
+        @Test
+        void 실패_비활성화계정() {
+            // given
+            Long sellerPk = inactiveSeller.getPk();
+            String currentRaw = "password";
+            String newRaw = "newPassword";
+
+            when(sellerRepository.findByPkAndActiveTrue(sellerPk)).thenReturn(Optional.empty());
+
+            // when
+            PinkCatException ex = assertThrows(PinkCatException.class, () ->
+                    sellerService.updatePassword(
+                            sellerPk, new SellerUpdatePasswordRequestDto(currentRaw, newRaw)));
+
+            // then
+            assertEquals(ErrorMessageCode.SELLER_INACTIVE_EXCEPTION, ex.getPinkCatErrorMessageCode());
+        }
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항
ℹ️ Entity와 Repository는 Kotlin, 나머지 로직은 Java로 작성

- 마이페이지 내 정보 조회 API 구현  
  - 현재 로그인된 판매자의 정보(`sellerId`, `sellerName`, `store 정보` 등) 반환
- 마이페이지 비밀번호 수정 API 및 테스트 코드 구현  
- `product` 테스트 코드에 `sellerId` 정보 추가  

---

### 확인 사항

- [x] Postman으로 정상 응답 확인
- [x] 테스트 코드 통과
- [x] DB 조회, 수정 확인