### PR TITLE
feat: Refresh Token 재발급 API 구현 / refactor: RefreshToken 전달 방식 HttpOnly 쿠키로 변경

### DIFF
--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal UserPrincipal user) {
-        authService.logout(user.getUsername());
+        authService.logout(user.getUserPk());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
@@ -2,16 +2,16 @@ package com.pinkcat.quick_reserve_seller.auth.controller;
 
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.RefreshTokenResponseDto;
 import com.pinkcat.quick_reserve_seller.auth.service.AuthService;
 import com.pinkcat.quick_reserve_seller.common.security.principal.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +21,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto) {
-        return ResponseEntity.ok(authService.login(dto));
+    public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto, HttpServletResponse response) {
+        return ResponseEntity.ok(authService.login(dto, response));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/controller/AuthController.java
@@ -30,4 +30,12 @@ public class AuthController {
         authService.logout(user.getUserPk());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshTokenResponseDto> refreshAccessToken(
+            HttpServletRequest request
+            , HttpServletResponse response
+    ) {
+        return ResponseEntity.ok(authService.refreshAccessToken(request, response));
+    }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/LoginResponseDto.java
@@ -9,5 +9,4 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponseDto {
   private String accessToken;
-  private String refreshToken;
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/RefreshTokenResponseDto.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/dto/RefreshTokenResponseDto.java
@@ -1,0 +1,14 @@
+package com.pinkcat.quick_reserve_seller.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenResponseDto {
+    private String accessToken;
+}

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
@@ -3,10 +3,13 @@ package com.pinkcat.quick_reserve_seller.auth.service;
 
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.RefreshTokenResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
-    LoginResponseDto login(LoginRequestDto dto);
+    LoginResponseDto login(LoginRequestDto dto, HttpServletResponse response);
 
     void logout(Long userPk);
 

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthService.java
@@ -8,5 +8,7 @@ public interface AuthService {
 
     LoginResponseDto login(LoginRequestDto dto);
 
-    void logout(String accessToken);
+    void logout(Long userPk);
+
+    RefreshTokenResponseDto refreshAccessToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
@@ -2,16 +2,22 @@ package com.pinkcat.quick_reserve_seller.auth.service;
 
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.RefreshTokenResponseDto;
 import com.pinkcat.quick_reserve_seller.common.redis.RefreshTokenStore;
 import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtTokenProvider;
+import com.pinkcat.quick_reserve_seller.common.security.jwt.RefreshTokenCookieProvider;
 import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
 import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.WebUtils;
 
 @Slf4j
 @Service
@@ -25,7 +31,7 @@ public class AuthServiceImpl implements AuthService {
     private final RefreshTokenStore refreshTokenStore;
 
     @Override
-    public LoginResponseDto login(LoginRequestDto dto) {
+    public LoginResponseDto login(LoginRequestDto dto, HttpServletResponse response) {
         SellerEntity user =
                 userRepository
                         .findById(dto.getUserId())
@@ -47,7 +53,7 @@ public class AuthServiceImpl implements AuthService {
         response.addCookie(rtCookie);
 
         log.info("[로그인 성공] userId={}", user.getId());
-        return LoginResponseDto.builder().accessToken(accessToken).refreshToken(refreshToken).build();
+        return new LoginResponseDto(accessToken);
     }
 
     @Override

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
@@ -40,14 +40,18 @@ public class AuthServiceImpl implements AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getPk());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getPk());
 
-        refreshTokenStore.save(user.getId(), refreshToken);
+        refreshTokenStore.save(user.getPk(), refreshToken);
+
+        Cookie rtCookie = refreshTokenCookieProvider.createRefreshTokenCookie(refreshToken);
+        response.addCookie(rtCookie);
+
         log.info("[로그인 성공] userId={}", user.getId());
         return LoginResponseDto.builder().accessToken(accessToken).refreshToken(refreshToken).build();
     }
 
     @Override
-    public void logout(String userId) {
-        refreshTokenStore.delete(userId);
-        log.info("[로그아웃 성공] userId={}", userId);
+    public void logout(Long userPk) {
+        refreshTokenStore.delete(userPk);
+        log.info("[로그아웃 성공] userId={}", userPk);
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImpl.java
@@ -21,6 +21,7 @@ public class AuthServiceImpl implements AuthService {
     private final SellerRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenCookieProvider refreshTokenCookieProvider;
     private final RefreshTokenStore refreshTokenStore;
 
     @Override
@@ -53,5 +54,39 @@ public class AuthServiceImpl implements AuthService {
     public void logout(Long userPk) {
         refreshTokenStore.delete(userPk);
         log.info("[로그아웃 성공] userId={}", userPk);
+    }
+
+    @Override
+    public RefreshTokenResponseDto refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie rtCookie = WebUtils.getCookie(request, "refresh_token");
+        if (rtCookie == null) {
+            log.warn("[토큰 재발급 실패] RefreshToken 쿠키가 존재하지 않습니다.");
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "RefreshToken 쿠키가 존재하지 않습니다.");
+        }
+
+        String refreshToken = rtCookie.getValue();
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("[토큰 재발급 실패] RefreshToken이 유효하지 않습니다.");
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "RefreshToken이 유효하지 않습니다.");
+        }
+
+        Long userPk = jwtTokenProvider.getUserPk(refreshToken);
+
+        if (!refreshTokenStore.isValid(userPk, refreshToken)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "RefreshToken 정보가 일치하지 않습니다.");
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(userPk);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userPk);
+
+        refreshTokenStore.save(userPk, newRefreshToken);
+        Cookie newRtCookie = refreshTokenCookieProvider.createRefreshTokenCookie(newRefreshToken);
+        response.addCookie(newRtCookie);
+
+        return new RefreshTokenResponseDto(newAccessToken);
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RefreshTokenStore.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/redis/RefreshTokenStore.java
@@ -12,25 +12,25 @@ import java.time.Duration;
 public class RefreshTokenStore {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String PREFIX = "RT:ADMIN:";
+    private static final String PREFIX = "RT:SELLER:";
 
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
 
-    public void save(String userId, String refreshToken) {
-        redisTemplate.opsForValue().set(PREFIX + userId, refreshToken, Duration.ofDays(refreshExpiration));
+    public void save(Long userPk, String refreshToken) {
+        redisTemplate.opsForValue().set(PREFIX + userPk, refreshToken, Duration.ofDays(refreshExpiration));
     }
 
-    public String get(String userId) {
-        return redisTemplate.opsForValue().get(PREFIX + userId);
+    public String get(Long userPk) {
+        return redisTemplate.opsForValue().get(PREFIX + userPk);
     }
 
-    public void delete(String userId) {
-        redisTemplate.delete(PREFIX + userId);
+    public void delete(Long userPk) {
+        redisTemplate.delete(PREFIX + userPk);
     }
 
-    public boolean isValid(String userId, String refreshToken) {
-        String stored = get(userId);
+    public boolean isValid(Long userPk, String refreshToken) {
+        String stored = get(userPk);
         return refreshToken.equals(stored);
     }
 }

--- a/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/pinkcat/quick_reserve_seller/common/security/jwt/RefreshTokenCookieProvider.java
@@ -1,0 +1,27 @@
+package com.pinkcat.quick_reserve_seller.common.security.jwt;
+
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+    @Value("${jwt.cookie.refresh-token.path}")
+    private String refreshTokenCookiePath;
+
+    @Value("${jwt.cookie.refresh-token.secure}")
+    private boolean refreshTokenCookieSecure;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    public Cookie createRefreshTokenCookie(String token) {
+        Cookie cookie = new Cookie("refresh_token", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(refreshTokenCookieSecure);
+        cookie.setPath(refreshTokenCookiePath);
+        cookie.setMaxAge((int) (refreshExpiration / 1000));
+        return cookie;
+    }
+}

--- a/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
@@ -33,6 +33,8 @@ class AuthServiceImplTest {
     private JwtTokenProvider jwtTokenProvider;
     @Mock
     private RefreshTokenStore refreshTokenStore;
+    @Mock
+    private RefreshTokenCookieProvider refreshTokenCookieProvider;
 
     @InjectMocks
     private AuthServiceImpl authService;
@@ -134,6 +136,70 @@ class AuthServiceImplTest {
 
             // then
             verify(refreshTokenStore).delete(userId);
+        }
+    }
+
+    @Nested
+    class RefreshTokenTest {
+
+        @Test
+        void 성공() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            Cookie cookie = new Cookie("refresh_token", "test-refresh-token");
+            request.setCookies(cookie);
+
+            when(jwtTokenProvider.validateToken("test-refresh-token")).thenReturn(true);
+            when(jwtTokenProvider.getUserPk("test-refresh-token")).thenReturn(1L);
+            when(refreshTokenStore.isValid(1L, "test-refresh-token")).thenReturn(true);
+            when(jwtTokenProvider.createAccessToken(1L)).thenReturn("new-access-token");
+            when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("new-refresh-token");
+            Cookie newCookie = new Cookie("refresh_token", "new-refresh-token");
+            when(refreshTokenCookieProvider.createRefreshTokenCookie("new-refresh-token")).thenReturn(newCookie);
+
+            RefreshTokenResponseDto result = authService.refreshAccessToken(request, response);
+
+            assertEquals("new-access-token", result.getAccessToken());
+            assertNotNull(response.getCookie("refresh_token"));
+            assertEquals("new-refresh-token", response.getCookie("refresh_token").getValue());
+        }
+
+        @Test
+        void 실패_쿠키없음() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> authService.refreshAccessToken(request, response));
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        }
+
+        @Test
+        void 실패_토큰유효하지않음() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            request.setCookies(new Cookie("refresh_token", "invalid-refresh-token"));
+
+            when(jwtTokenProvider.validateToken("invalid-refresh-token")).thenReturn(false);
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> authService.refreshAccessToken(request, response));
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        }
+
+        @Test
+        void 실패_저장된토큰과불일치() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            request.setCookies(new Cookie("refresh_token", "invalid-refresh-token"));
+
+            when(jwtTokenProvider.validateToken("invalid-refresh-token")).thenReturn(true);
+            when(jwtTokenProvider.getUserPk("invalid-refresh-token")).thenReturn(1L);
+            when(refreshTokenStore.isValid(1L, "invalid-refresh-token")).thenReturn(false);
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> authService.refreshAccessToken(request, response));
+            assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
         }
     }
 }

--- a/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/pinkcat/quick_reserve_seller/auth/service/AuthServiceImplTest.java
@@ -2,11 +2,14 @@ package com.pinkcat.quick_reserve_seller.auth.service;
 
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginRequestDto;
 import com.pinkcat.quick_reserve_seller.auth.dto.LoginResponseDto;
+import com.pinkcat.quick_reserve_seller.auth.dto.RefreshTokenResponseDto;
 import com.pinkcat.quick_reserve_seller.common.redis.RefreshTokenStore;
 import com.pinkcat.quick_reserve_seller.common.security.jwt.JwtTokenProvider;
+import com.pinkcat.quick_reserve_seller.common.security.jwt.RefreshTokenCookieProvider;
 import com.pinkcat.quick_reserve_seller.seller.entity.SellerEntity;
 import com.pinkcat.quick_reserve_seller.seller.repository.SellerRepository;
 import com.pinkcat.quick_reserve_seller.store.entity.StoreEntity;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -62,18 +67,23 @@ class AuthServiceImplTest {
         void 성공() {
             // given
             LoginRequestDto loginDto = new LoginRequestDto("testuser", "rawpass");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
             when(userRepository.findById("testuser")).thenReturn(Optional.of(userEntity));
             when(passwordEncoder.matches("rawpass", "encoded_pass")).thenReturn(true);
             when(jwtTokenProvider.createAccessToken(1L)).thenReturn("access-token");
             when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
+            Cookie mockCookie = new Cookie("refresh_token", "test-refresh-token");
+            when(refreshTokenCookieProvider.createRefreshTokenCookie("refresh-token")).thenReturn(mockCookie);
 
             // when
-            LoginResponseDto result = authService.login(loginDto);
+            LoginResponseDto result = authService.login(loginDto, response);
 
             // then
             assertEquals("access-token", result.getAccessToken());
-            assertEquals("refresh-token", result.getRefreshToken());
-            verify(refreshTokenStore).save("testuser", "refresh-token");
+            assertNotNull(response.getCookie("refresh_token"));
+            assertEquals("test-refresh-token", response.getCookie("refresh_token").getValue());
+            verify(refreshTokenStore).save(1L, "refresh-token");
         }
 
         @Test
@@ -84,7 +94,7 @@ class AuthServiceImplTest {
 
             // when
             ResponseStatusException ex =
-                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto, new MockHttpServletResponse()));
 
             // then
             assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
@@ -99,7 +109,7 @@ class AuthServiceImplTest {
 
             // when
             ResponseStatusException ex =
-                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto, new MockHttpServletResponse()));
 
             // then
             assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
@@ -115,7 +125,7 @@ class AuthServiceImplTest {
 
             // when
             ResponseStatusException ex =
-                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto));
+                    assertThrows(ResponseStatusException.class, () -> authService.login(loginDto, new MockHttpServletResponse()));
 
             // then
             assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
@@ -129,13 +139,13 @@ class AuthServiceImplTest {
         @Test
         void 성공() {
             // given
-            String userId = "testuser";
+            Long userPk = 1L;
 
             // when
-            assertDoesNotThrow(() -> authService.logout(userId));
+            assertDoesNotThrow(() -> authService.logout(userPk));
 
             // then
-            verify(refreshTokenStore).delete(userId);
+            verify(refreshTokenStore).delete(userPk);
         }
     }
 


### PR DESCRIPTION
### 주요 변경 사항
- 토큰 재발급 API 구현
  - 기존 refreshToken을 매번 갱신하는 Token Rotation 방식 적용
- 로그인 시 RefreshToken 전달 방식 변경
  - dto로 받는 방식에서 HttpOnly 쿠키로만 전달되도록 구조 수정
- Redis RefreshTokenStore 키 구성 방식 수정
  - 키 Prefix를 SELLER로 명시, 수정
  - userId → userPk 기준으로 수정하여 중복 위험 방지 및 일관성 확보
---

### 확인 사항

- [x] Postman으로 정상 응답 확인
- [x] 테스트 코드 통과
- [x] DB 조회, 생성, 삭제 확인
- [x] Redis를 통한 RefreshToken 저장 확인  